### PR TITLE
fix: 在配置了新建页面的情况下，详情页新建沿用该配置

### DIFF
--- a/src/views/customize-menu/NewWindowCreateEntity.vue
+++ b/src/views/customize-menu/NewWindowCreateEntity.vue
@@ -96,6 +96,18 @@ onMounted(() => {
 	entity.value = router.currentRoute.value.params.entityName;
 	formId.value = router.currentRoute.value.query.formId;
     recordId.value = null;
+
+	// 保存关联字段信息到 globalDsv，用于表单初始化时自动填充
+	const fieldName = router.currentRoute.value.query.fieldName || '';
+	const fieldNameVale = router.currentRoute.value.query.fieldNameVale || '';
+	const fieldNameLabel = router.currentRoute.value.query.fieldNameLabel || '';
+
+	if(fieldName && fieldNameVale) {
+		globalDsv.value.relatedFieldName = fieldName;
+		globalDsv.value.relatedFieldValue = fieldNameVale;
+		globalDsv.value.relatedFieldLabel = fieldNameLabel;
+	}
+
 	// 加载表单
 	loadForm();
 });
@@ -157,6 +169,15 @@ const loadForm = async () => {
                         })
                     }
                 }
+
+				// 处理关联字段自动填充
+				if(globalDsv.value.relatedFieldName && globalDsv.value.relatedFieldValue) {
+					const relatedFieldData = {};
+					relatedFieldData[globalDsv.value.relatedFieldName] = globalDsv.value.relatedFieldValue;
+					nextTick(() => {
+						vFormRef.value?.setFormData(relatedFieldData);
+					});
+				}
 			});
 		}
 	}

--- a/src/views/customize-menu/components/DetailTabCom.vue
+++ b/src/views/customize-menu/components/DetailTabCom.vue
@@ -143,7 +143,11 @@
             </div>
         </div>
     </div>
-    <Detail ref="detailRefs" @onConfirm="getTableList" />
+    <Detail
+        ref="detailRefs"
+        @onConfirm="getTableList"
+        :recordDetailFormId="computedRecordDetailFormId"
+    />
 </template>
 
 <script setup>
@@ -234,6 +238,22 @@ const tableMaxHeight = computed(() => {
     // return document.querySelector('.detail-tab-container').clientHeight - 240;
     // console.log(document.querySelector('.detail-tab-container'))
     return 'calc(100vh - 230px)';
+});
+
+// 计算属性：从 layoutConfig 中提取 pcDetailFormId
+const computedRecordDetailFormId = computed(() => {
+    let styleConf = {};
+    if (layoutConfig.value.STYLE && layoutConfig.value.STYLE.config) {
+        try {
+            styleConf = typeof layoutConfig.value.STYLE.config === 'string'
+                ? JSON.parse(layoutConfig.value.STYLE.config)
+                : layoutConfig.value.STYLE.config;
+        } catch (err) {
+            console.error('解析 STYLE 配置失败:', err);
+            return '';
+        }
+    }
+    return styleConf?.formConf?.pcDetailFormId || '';
 });
 
 // 卡片视图排序
@@ -390,7 +410,25 @@ const openDetailDialog = (row) => {
     if(!idFieldName.value){
         return
     }
-    detailRefs.value.openDialog(row[idFieldName.value]);
+
+    // 从 layoutConfig.STYLE.config 中解析配置
+    let styleConf = {};
+    if (layoutConfig.value.STYLE && layoutConfig.value.STYLE.config) {
+        try {
+            styleConf = typeof layoutConfig.value.STYLE.config === 'string'
+                ? JSON.parse(layoutConfig.value.STYLE.config)
+                : layoutConfig.value.STYLE.config;
+        } catch (err) {
+            console.error('解析 STYLE 配置失败:', err);
+            styleConf = {};
+        }
+    }
+
+    // 提取 pcDetailFormId 配置
+    const formId = styleConf?.formConf?.pcDetailFormId || '';
+
+    // 传递 formId 参数给 openDialog
+    detailRefs.value.openDialog(row[idFieldName.value], null, formId);
 };
 // 列排序
 const sortChange = (column) => {

--- a/src/views/customize-menu/detail.vue
+++ b/src/views/customize-menu/detail.vue
@@ -1008,16 +1008,64 @@ const onAdd = (e, outerLayoutConfig) => {
 	tempV.fieldNameVale = detailId.value;
 	tempV.fieldNameLabel = detailName.value;
 	tempV.sourceRecord = multipleSelection.value[0];
-    if(e.formId) {
-        tempV.formId = e.formId;
-    }
-    if(e.localDsv) {
-        tempV.localDsv = e.localDsv;
-    }
-    if(outerLayoutConfig) {
-        myLayoutConfig.value = {...outerLayoutConfig};
-    }
-    editRefs.value.openDialog(tempV);
+
+	// 解析 STYLE 配置
+	let rowStyleConf = {};
+	if(outerLayoutConfig?.STYLE?.config) {
+		try {
+			rowStyleConf = typeof outerLayoutConfig.STYLE.config === 'string'
+				? JSON.parse(outerLayoutConfig.STYLE.config)
+				: outerLayoutConfig.STYLE.config;
+		} catch(err) {
+			console.error('解析 STYLE 配置失败:', err);
+			rowStyleConf = {};
+		}
+	}
+
+	// 检查是否配置了新页签打开新建
+	if(rowStyleConf.actionConf?.newTabOpenNew) {
+		// 保存 localDsv 到 localStorage
+		localStorage.setItem("NewWindowCreateEntityLocalDsv", JSON.stringify({
+			entity: e.entityName,
+			localDsv: e.localDsv || {},
+		}));
+
+		// 跳转到新窗口创建实体页面
+		router.push({
+			name: "NewWindowCreateEntity",
+			params: {
+				entityName: e.entityName,
+			},
+			query: {
+				entity: e.entityName,
+				type: "new",
+				// 优先级：事件参数 > STYLE.formConf.pcAddFormId
+				formId: e.formId || rowStyleConf.formConf?.pcAddFormId || '',
+				// 关联字段信息
+				fieldName: e.fieldName,
+				fieldNameVale: detailId.value,
+				fieldNameLabel: detailName.value,
+			}
+		});
+		return;
+	}
+
+	// 原有的弹窗打开逻辑
+	if(e.formId) {
+		tempV.formId = e.formId;
+	} else if(rowStyleConf.formConf?.pcAddFormId) {
+		// 如果没有从事件传入 formId，使用配置的表单ID
+		tempV.formId = rowStyleConf.formConf.pcAddFormId;
+	}
+
+	if(e.localDsv) {
+		tempV.localDsv = e.localDsv;
+	}
+	if(outerLayoutConfig) {
+		myLayoutConfig.value = {...outerLayoutConfig};
+	}
+
+	editRefs.value.openDialog(tempV);
 };
 
 


### PR DESCRIPTION
美乐的详情页新建页面默认采用所有表单列表的第一个表单（按名称排序），这个MR可以让详情页新建页面沿用关联实体的新建页面配置